### PR TITLE
Navigation flux to Cart Screen to Checkout Screens

### DIFF
--- a/src/navigation/loggedNav.jsx
+++ b/src/navigation/loggedNav.jsx
@@ -1,13 +1,14 @@
-import React, { Component } from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import OnCategories from './onCategories';
-import OnHome from './onHome';
-import OnWishlist from './onWishlist'
-import { FontAwesome5, FontAwesome, AntDesign } from '@expo/vector-icons';
-import UserProfile from '../screens/UserProfile';
-import Checkout from '../screens/Checkout/Checkout1';
-import Checkout2 from '../screens/Checkout/Checkout2';
-import Cart from '../screens/Cart';
+import React, { Component } from "react";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import OnCategories from "./onCategories";
+import OnHome from "./onHome";
+import OnCart from "./onCart";
+import OnWishlist from "./onWishlist";
+import { FontAwesome5, FontAwesome, AntDesign } from "@expo/vector-icons";
+import UserProfile from "../screens/UserProfile";
+import Checkout from "../screens/Checkout/Checkout1";
+import Checkout2 from "../screens/Checkout/Checkout2";
+import Cart from "../screens/Cart";
 
 const Tab = createBottomTabNavigator();
 
@@ -19,53 +20,53 @@ export default class LoggedNav extends Component {
   render() {
     return (
       <Tab.Navigator
-        initialRouteName='Checkout2'
+        initialRouteName="Checkout2"
         screenOptions={{
           tabBarShowLabel: false,
           headerShown: false,
-          headerTitle: '',
+          headerTitle: "",
         }}
       >
         <Tab.Screen
-          name='OnHome'
+          name="OnHome"
           component={OnHome}
           options={{
             tabBarIcon: ({ color, size }) => (
-              <FontAwesome name={'home'} size={size} color={color} />
+              <FontAwesome name={"home"} size={size} color={color} />
             ),
           }}
         />
 
         <Tab.Screen
-          name='OnCategories'
+          name="OnCategories"
           component={OnCategories}
           options={{
             tabBarIcon: ({ color, size }) => (
-              <FontAwesome name={'th-large'} size={size} color={color} />
+              <FontAwesome name={"th-large"} size={size} color={color} />
             ),
           }}
         />
 
         <Tab.Screen
-          name='OnWishlist'
+          name="OnWishlist"
           component={OnWishlist}
           options={{
             tabBarIcon: ({ color, size }) => (
-              <FontAwesome name={'heart'} size={size} color={color} />
+              <FontAwesome name={"heart"} size={size} color={color} />
             ),
           }}
         />
 
         <Tab.Screen
-          name='Checkout'
+          name="Checkout"
           component={Checkout}
           options={{
             headerShown: true,
             tabBarButton: () => null,
             headerLeft: (props) => (
               <FontAwesome5
-                onPress={() => this.props.navigation.navigate('UserProfile')}
-                name='user-circle'
+                onPress={() => this.props.navigation.navigate("UserProfile")}
+                name="user-circle"
                 style={{ marginLeft: 15 }}
                 size={30}
                 color={props.tintColor}
@@ -73,8 +74,8 @@ export default class LoggedNav extends Component {
             ),
             headerRight: (props) => (
               <AntDesign
-                onPress={() => this.props.navigation.navigate('Cart')}
-                name='shoppingcart'
+                onPress={() => this.props.navigation.navigate("Cart")}
+                name="shoppingcart"
                 size={30}
                 style={{ marginRight: 15 }}
                 color={props.tintColor}
@@ -84,15 +85,15 @@ export default class LoggedNav extends Component {
         />
 
         <Tab.Screen
-          name='Checkout2'
+          name="Checkout2"
           component={Checkout2}
           options={{
             headerShown: true,
             tabBarButton: () => null,
             headerLeft: (props) => (
               <FontAwesome5
-                onPress={() => this.props.navigation.navigate('UserProfile')}
-                name='user-circle'
+                onPress={() => this.props.navigation.navigate("UserProfile")}
+                name="user-circle"
                 style={{ marginLeft: 15 }}
                 size={30}
                 color={props.tintColor}
@@ -100,8 +101,8 @@ export default class LoggedNav extends Component {
             ),
             headerRight: (props) => (
               <AntDesign
-                onPress={() => this.props.navigation.navigate('Cart')}
-                name='shoppingcart'
+                onPress={() => this.props.navigation.navigate("Cart")}
+                name="shoppingcart"
                 size={30}
                 style={{ marginRight: 15 }}
                 color={props.tintColor}
@@ -111,14 +112,14 @@ export default class LoggedNav extends Component {
         />
 
         <Tab.Screen
-          name='UserProfile'
+          name="UserProfile"
           component={UserProfile}
           options={{
             headerShown: true,
             tabBarButton: () => null,
             headerLeft: (props) => (
               <FontAwesome5
-                name='user-circle'
+                name="user-circle"
                 style={{ marginLeft: 15 }}
                 size={30}
                 color={props.tintColor}
@@ -126,8 +127,8 @@ export default class LoggedNav extends Component {
             ),
             headerRight: (props) => (
               <AntDesign
-                onPress={() => this.props.navigation.navigate('Cart')}
-                name='shoppingcart'
+                onPress={() => this.props.navigation.navigate("Cart")}
+                name="shoppingcart"
                 size={30}
                 style={{ marginRight: 15 }}
                 color={props.tintColor}
@@ -137,15 +138,15 @@ export default class LoggedNav extends Component {
         />
 
         <Tab.Screen
-          name='Cart'
+          name="Cart"
           component={Cart}
           options={{
             headerShown: true,
             tabBarButton: () => null,
             headerLeft: (props) => (
               <FontAwesome5
-                onPress={() => this.props.navigation.navigate('UserProfile')}
-                name='user-circle'
+                onPress={() => this.props.navigation.navigate("UserProfile")}
+                name="user-circle"
                 style={{ marginLeft: 15 }}
                 size={30}
                 color={props.tintColor}
@@ -153,7 +154,7 @@ export default class LoggedNav extends Component {
             ),
             headerRight: (props) => (
               <AntDesign
-                name='shoppingcart'
+                name="shoppingcart"
                 size={30}
                 style={{ marginRight: 15 }}
                 color={props.tintColor}

--- a/src/navigation/onCart.jsx
+++ b/src/navigation/onCart.jsx
@@ -1,0 +1,54 @@
+import React, { Component } from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import Checkout from "../screens/Checkout/Checkout1";
+import Checkout2 from "../screens/Checkout/Checkout2";
+import Cart from "../screens/Cart";
+import { FontAwesome5, AntDesign } from "@expo/vector-icons";
+import UserProfile from "../screens/UserProfile";
+import SearchInput from "../components/SearchInput";
+
+const Stack = createNativeStackNavigator();
+
+export default class OnCart extends Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <Stack.Navigator
+        initialRouteName="Cart"
+        screenOptions={{
+          headerShown: true,
+          headerBackVisible: false,
+          headerLeft: (props) => (
+            <FontAwesome5
+              name="user-circle"
+              onPress={() => this.props.navigation.navigate("UserProfile")}
+              size={30}
+              color={props.tintColor}
+            />
+          ),
+          headerRight: (props) => (
+            <AntDesign
+              onPress={() => this.props.navigation.navigate("Cart")}
+              name="shoppingcart"
+              size={30}
+              color={props.tintColor}
+            />
+          ),
+          headerTitle: () => (
+            <SearchInput
+              onSearch={(text) => this.changeText(text)}
+              value={this.state.search}
+            />
+          ),
+          headerTitleAlign: "center",
+        }}
+      >
+        <Stack.Screen name="Checkout" component={Checkout} />
+
+        <Stack.Screen name="Checkout2" component={Checkout2} />
+      </Stack.Navigator>
+    );
+  }
+}


### PR DESCRIPTION
# Description
### What?
- Implementation of the navigation flux from the Cart screen to the Checkout screens.
- See #43 for more information
### Why
- Include the new screens to the navigation flux of the app
- See #43 for more information.

## Testing

- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- then you can initialize with an android emulator or via web
```npm start```

## Screenshots

| Cart Screen   |      Checkout Screens      |
|----------|:-------------:|
| ![cart](https://user-images.githubusercontent.com/102479612/227067661-5eb33e8c-f7da-49e6-8df4-a75f8d25e0d5.png) | ![firstcheckout](https://user-images.githubusercontent.com/102479612/227067947-588dce20-4fee-4dbb-87ff-5a7754a20401.png) ![secondcheckout](https://user-images.githubusercontent.com/102479612/227068007-55b72415-91e0-4bfc-b8a2-8ab947a49c64.png) ![thirdcheckout](https://user-images.githubusercontent.com/102479612/227068045-99259b7d-b843-4c80-8cd6-ed9ff1fad93f.png) |