### PR TITLE
Fixed a navigation problem in Home and Franchises

### DIFF
--- a/src/navigation/loggedNav.jsx
+++ b/src/navigation/loggedNav.jsx
@@ -9,6 +9,7 @@ import UserProfile from "../screens/UserProfile";
 import Cart from "../screens/Cart";
 import OnCheckout from "./onCheckout";
 import OnProductDetail from "./onProductDetail";
+import { navigations } from "../styles/NavStyles";
 
 const Tab = createBottomTabNavigator();
 export default class LoggedNav extends Component {
@@ -48,7 +49,7 @@ export default class LoggedNav extends Component {
               <FontAwesome5
                 onPress={() => this.props.navigation.navigate("UserProfile")}
                 name="user-circle"
-                style={{ marginLeft: 15 }}
+                style={navigations.iconUser}
                 size={30}
                 color={props.tintColor}
               />
@@ -57,7 +58,7 @@ export default class LoggedNav extends Component {
               <AntDesign
                 name="shoppingcart"
                 size={30}
-                style={{ marginRight: 15 }}
+                style={navigations.iconcart}
                 color={props.tintColor}
               />
             ),
@@ -96,7 +97,7 @@ export default class LoggedNav extends Component {
               <FontAwesome5
                 onPress={() => this.props.navigation.navigate("UserProfile")}
                 name="user-circle"
-                style={{ marginLeft: 15 }}
+                style={navigations.iconUser}
                 size={30}
                 color={props.tintColor}
               />
@@ -106,7 +107,7 @@ export default class LoggedNav extends Component {
                 onPress={() => this.props.navigation.navigate("Cart")}
                 name="shoppingcart"
                 size={30}
-                style={{ marginRight: 15 }}
+                style={navigations.iconcart}
                 color={props.tintColor}
               />
             ),
@@ -123,7 +124,7 @@ export default class LoggedNav extends Component {
               <FontAwesome5
                 onPress={() => this.props.navigation.navigate("UserProfile")}
                 name="user-circle"
-                style={{ marginLeft: 15 }}
+                style={navigations.iconUser}
                 size={30}
                 color={props.tintColor}
               />
@@ -133,7 +134,7 @@ export default class LoggedNav extends Component {
                 onPress={() => this.props.navigation.navigate("Cart")}
                 name="shoppingcart"
                 size={30}
-                style={{ marginRight: 15 }}
+                style={navigations.iconcart}
                 color={props.tintColor}
               />
             ),
@@ -149,7 +150,7 @@ export default class LoggedNav extends Component {
               <FontAwesome5
                 onPress={() => this.props.navigation.navigate("UserProfile")}
                 name="user-circle"
-                style={{ marginLeft: 15 }}
+                style={navigations.iconUser}
                 size={30}
                 color={props.tintColor}
               />
@@ -158,7 +159,7 @@ export default class LoggedNav extends Component {
               <AntDesign
                 name="shoppingcart"
                 size={30}
-                style={{ marginRight: 15 }}
+                style={navigations.iconcart}
                 color={props.tintColor}
               />
             ),

--- a/src/navigation/loggedNav.jsx
+++ b/src/navigation/loggedNav.jsx
@@ -37,6 +37,33 @@ export default class LoggedNav extends Component {
           }}
         />
 
+<Tab.Screen
+          name="OnProductDetail"
+          component={OnProductDetail}
+          options={{
+            headerShown: true,
+            headerBackVisible: false,
+            tabBarButton: () => null,
+            headerLeft: (props) => (
+              <FontAwesome5
+                onPress={() => this.props.navigation.navigate("UserProfile")}
+                name="user-circle"
+                style={{ marginLeft: 15 }}
+                size={30}
+                color={props.tintColor}
+              />
+            ),
+            headerRight: (props) => (
+              <AntDesign
+                name="shoppingcart"
+                size={30}
+                style={{ marginRight: 15 }}
+                color={props.tintColor}
+              />
+            ),
+          }}
+        />
+
         <Tab.Screen
           name="OnCategories"
           component={OnCategories}

--- a/src/navigation/loggedNav.jsx
+++ b/src/navigation/loggedNav.jsx
@@ -37,7 +37,7 @@ export default class LoggedNav extends Component {
           }}
         />
 
-<Tab.Screen
+        <Tab.Screen
           name="OnProductDetail"
           component={OnProductDetail}
           options={{

--- a/src/screens/Categories/Franchises.jsx
+++ b/src/screens/Categories/Franchises.jsx
@@ -1,4 +1,4 @@
-import { Text, View, FlatList, ScrollView } from "react-native";
+import { Text, View, FlatList, ScrollView, TouchableOpacity, } from "react-native";
 import React, { Component } from "react";
 import { containers } from "../../styles/FranchisesScreen/Screen_Franchises";
 import { titles } from "../../styles/FranchisesScreen/Screen_Franchises";
@@ -84,7 +84,16 @@ export default class Franchises extends Component {
                     )}
                     renderItem={({ item:product }) => {
                       return (
+                      <TouchableOpacity
+                        onPress={() => {
+                          this.props.navigation.navigate("OnProductDetail", {
+                            screen: "ProductDetail",
+                            params: { id: product.id },
+                          });
+                        }}
+                      >
                         <ProductItem product={product} isFavorite={this.state.favorites.includes(product.id)} />
+                  </TouchableOpacity>
                       );
                     }}
                   />

--- a/src/screens/Categories/Franchises.jsx
+++ b/src/screens/Categories/Franchises.jsx
@@ -84,16 +84,16 @@ export default class Franchises extends Component {
                     )}
                     renderItem={({ item:product }) => {
                       return (
-                      <TouchableOpacity
-                        onPress={() => {
-                          this.props.navigation.navigate("OnProductDetail", {
-                            screen: "ProductDetail",
-                            params: { id: product.id },
-                          });
-                        }}
-                      >
-                        <ProductItem product={product} isFavorite={this.state.favorites.includes(product.id)} />
-                  </TouchableOpacity>
+                        <TouchableOpacity
+                          onPress={() => {
+                            this.props.navigation.navigate("OnProductDetail", {
+                              screen: "ProductDetail",
+                              params: { id: product.id },
+                            });
+                          }}
+                        >
+                          <ProductItem product={product} isFavorite={this.state.favorites.includes(product.id)} />
+                        </TouchableOpacity>
                       );
                     }}
                   />

--- a/src/styles/NavStyles.jsx
+++ b/src/styles/NavStyles.jsx
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native";
+
+export const MARGINS = {
+  userIcon: 15,
+  shoppingCart: 15,
+};
+
+export const navigations = StyleSheet.create({
+  iconUser:{marginLeft: MARGINS.userIcon},
+  iconcart:{marginRight: MARGINS.shoppingCart},
+})


### PR DESCRIPTION
# Description

What did you implemented/Why did you implemented this:

- Fixed a problem that was preventing Home from showing the produc information screen.
- Implemented the navigation to the product information into the Categories/Franchises screen
- This following #60 

## Testing
- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- Then you can initialize with an android emulator or via web
```npm start```
- Login if you are registered
- Browse through the app
- Select any product to see its details

Help me how can I test or look at the changes

## Screenshots

![imagen](https://user-images.githubusercontent.com/28931958/232256268-4d9af4d5-7931-41d6-9b1c-1933bcd86bd4.png)
